### PR TITLE
[FIX] Nuevo campo en account.payment

### DIFF
--- a/account_tax_settlement/models/__init__.py
+++ b/account_tax_settlement/models/__init__.py
@@ -4,3 +4,4 @@ from . import account_move
 from . import account_journal_dashboard
 from . import account_financial_html_report_line
 from . import account_report
+from . import account_payment

--- a/account_tax_settlement/models/account_payment.py
+++ b/account_tax_settlement/models/account_payment.py
@@ -1,0 +1,8 @@
+from odoo import fields, models, api
+
+
+class AccountPayment(models.Model):
+    _inherit = 'account.payment'
+    _description = 'Description'
+
+    payment_date = fields.Date(string="Fecha de pago",related='payment_group_id.payment_date')


### PR DESCRIPTION
- A la hora de querer liquidar impuestos o descargar archivo de liquidacion, busca un campo en el pago llamado payment_date el cual no existe, lo que hago es crear un nuevo campo related y traigo la fecha de pago del payment.group asociado a este pago.