### PR TITLE
[FIX] Fix en liquidacion de impuesto diario SICORE

### DIFF
--- a/account_tax_settlement/models/account_journal.py
+++ b/account_tax_settlement/models/account_journal.py
@@ -50,6 +50,12 @@ class AccountJournal(models.Model):
         'account.financial.html.report',
         'Informe de liquidación',
     )
+
+    sequence_id = fields.Many2one(
+        'ir.sequence',
+        'Secuencia de entrada',
+    )
+
     # lo hacemos con etiquetas ya que se puede resolver con datos en plan
     # de cuentas sin incorporar lógica
     # TODO, por ahora son solo con tags de impuestos pero podrimoas dejar
@@ -164,9 +170,9 @@ class AccountJournal(models.Model):
             raise ValidationError(_(
                 'Settlement only allowed on journals with Tax Settlement '
                 'enable'))
-        # if not self.journal_id.sequence_id:
-        #     raise ValidationError(
-        #         _('Please define a sequence on the journal.'))
+        if not self.sequence_id:
+            raise ValidationError(
+                ('Por favor defina una secuencia para el diario %s.')%self.name)
         # queremos esta restriccion?
         if move_lines.filtered('tax_settlement_move_id'):
             raise ValidationError(_(

--- a/account_tax_settlement/views/account_journal_view.xml
+++ b/account_tax_settlement/views/account_journal_view.xml
@@ -15,6 +15,9 @@
                 <field name="settlement_financial_report_id" attrs="{'invisible': [('tax_settlement', '=', False)]}"/>
                 <field name="settlement_account_tag_ids" attrs="{'invisible': [('tax_settlement', '=', False)]}" widget="many2many_tags"/>
             </field>
+            <field name="code" position="after">
+                 <field name="sequence_id"/>
+            </field>
         </field>
     </record>
 

--- a/l10n_ar_account_tax_settlement/security/ir.model.access.csv
+++ b/l10n_ar_account_tax_settlement/security/ir.model.access.csv
@@ -1,3 +1,6 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_inflation_adjustment_index_user,inflation.adjustment.index.user,model_inflation_adjustment_index,,1,1,1,1
 access_inflation_adjustment_user,inflation.adjustment.user,model_inflation_adjustment,,1,1,1,1
+
+access_model_download_files_wizard_user,model_download_files_wizard,model_download_files_wizard,,1,1,1,1
+access_download_files_wizard_line_user,download_files_wizard_line,model_download_files_wizard_line,,1,1,1,1


### PR DESCRIPTION
 - Se  agrego campo sequence en el diario el cual estaba causando errores que  no permitia liquidar asientos de impuestos.
 - Se agrego permisos al descargo de archivo para liquidacion de impuestos.